### PR TITLE
Add validate function to return error slice

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -16,29 +16,7 @@ func Validate(password string, minEntropy float64) error {
 		return nil
 	}
 
-	hasReplace := false
-	hasSep := false
-	hasOtherSpecial := false
-	hasLower := false
-	hasUpper := false
-	hasDigits := false
-
-	for _, c := range password {
-		switch {
-		case strings.ContainsRune(replaceChars, c):
-			hasReplace = true
-		case strings.ContainsRune(sepChars, c):
-			hasSep = true
-		case strings.ContainsRune(otherSpecialChars, c):
-			hasOtherSpecial = true
-		case strings.ContainsRune(lowerChars, c):
-			hasLower = true
-		case strings.ContainsRune(upperChars, c):
-			hasUpper = true
-		case strings.ContainsRune(digitsChars, c):
-			hasDigits = true
-		}
-	}
+	hasReplace, hasSep, hasOtherSpecial, hasLower, hasUpper, hasDigits := getCharacterContainment(password)
 
 	allMessages := []string{}
 
@@ -63,4 +41,25 @@ func Validate(password string, minEntropy float64) error {
 	}
 
 	return errors.New("insecure password, try using a longer password")
+}
+
+func getCharacterContainment(password string) (hasReplace, hasSep, hasOtherSpecial, hasLower, hasUpper, hasDigits bool) {
+	for _, c := range password {
+		switch {
+		case strings.ContainsRune(replaceChars, c):
+			hasReplace = true
+		case strings.ContainsRune(sepChars, c):
+			hasSep = true
+		case strings.ContainsRune(otherSpecialChars, c):
+			hasOtherSpecial = true
+		case strings.ContainsRune(lowerChars, c):
+			hasLower = true
+		case strings.ContainsRune(upperChars, c):
+			hasUpper = true
+		case strings.ContainsRune(digitsChars, c):
+			hasDigits = true
+		}
+	}
+
+	return
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -33,3 +33,43 @@ func TestValidate(t *testing.T) {
 		t.Errorf("Wanted %v, got %v", expectedError, err)
 	}
 }
+
+func TestValidateWithErrorSlice(t *testing.T) {
+	errs := ValidateWithErrorSlice("mypass", 50)
+	expectedErrors := []error{ErrInsufficientSpecialCharacters, ErrNoUppercaseLetters, ErrNoDigits, ErrShortPassword}
+	testErrorSlice(t, errs, expectedErrors)
+
+	errs = ValidateWithErrorSlice("MYPASS", 50)
+	expectedErrors = []error{ErrInsufficientSpecialCharacters, ErrNoLowercaseLetters, ErrNoDigits, ErrShortPassword}
+	testErrorSlice(t, errs, expectedErrors)
+
+	errs = ValidateWithErrorSlice("mypassword", 4)
+	if errs != nil {
+		t.Errorf("Errs should be nil")
+	}
+
+	errs = ValidateWithErrorSlice("aGoo0dMi#oFChaR2", 80)
+	if errs != nil {
+		t.Errorf("Errs should be nil")
+	}
+
+	expectedErrors = []error{ErrInsufficientSpecialCharacters, ErrNoLowercaseLetters, ErrNoUppercaseLetters, ErrShortPassword}
+	errs = ValidateWithErrorSlice("123", 60)
+	testErrorSlice(t, errs, expectedErrors)
+}
+
+func testErrorSlice(t *testing.T, errs []error, expectedErrors []error) {
+	t.Helper()
+
+	if len(errs) != len(expectedErrors) {
+		t.Errorf("Wanted %v, got %v", expectedErrors, errs)
+		return
+	}
+
+	for i, err := range errs {
+		expectedError := expectedErrors[i]
+		if err.Error() != expectedError.Error() {
+			t.Errorf("Errs[%d]: Wanted %v, got %v", i, expectedError, err)
+		}
+	}
+}


### PR DESCRIPTION
Currently, the `Validate` function returns validation errors as a combined string.
It makes the client difficult to show custom messages to users.
In this PR, I added another function `ValidateWithErrorSlice` to return an error slice so the caller can handle errors properly.